### PR TITLE
Fix typo in function documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1094,7 +1094,7 @@ countVowels('sampleInput'); // 4
 
 Decapitalizes the first letter of a string.
 
-Decapitalizes the fist letter of the sring and then adds it with rest of the string. Omit the ```upperRest``` parameter to keep the rest of the string intact, or set it to ```true``` to convert to uppercase.
+Decapitalizes the first letter of the sring and then adds it with rest of the string. Omit the ```upperRest``` parameter to keep the rest of the string intact, or set it to ```true``` to convert to uppercase.
 
 ```php
 function decapitalize($string, $upperRest = false)


### PR DESCRIPTION
Change `fist` to `first`