### PR TITLE
Improved the `decapitalize` function

### DIFF
--- a/snippets/decapitalize.md
+++ b/snippets/decapitalize.md
@@ -7,7 +7,7 @@ Decapitalizes the first letter of the sring and then adds it with rest of the st
 ```php
 function decapitalize($string, $upperRest = false)
 {
-    return strtolower(substr($string, 0, 1)) . ($upperRest ? strtoupper(substr($string, 1)) : substr($string, 1));
+    return lcfirst($upperRest ? strtoupper($string) : $string);
 }
 ```
 

--- a/snippets/firstStringBetween.md
+++ b/snippets/firstStringBetween.md
@@ -5,15 +5,7 @@ Returns the first string there is between the strings from the parameter start a
 ```php
 function firstStringBetween($haystack, $start, $end)
 {
-    $char = strpos($haystack, $start);
-    if ($char === false) {
-        return '';
-    }
-
-    $char += strlen($start);
-    $len = strpos($haystack, $end, $char) - $char;
-
-    return substr($haystack, $char, $len);
+    return trim(strstr(strstr($haystack, $start), $end, true), $start . $end);
 }
 ```
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -292,7 +292,7 @@ function countVowels($string)
 
 function decapitalize($string, $upperRest = false)
 {
-    return strtolower(substr($string, 0, 1)) . ($upperRest ? strtoupper(substr($string, 1)) : substr($string, 1));
+    return lcfirst($upperRest ? strtoupper($string) : $string);
 }
 
 function approximatelyEqual($number1, $number2, $epsilon = 0.001)

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -237,15 +237,7 @@ function palindrome($string)
 
 function firstStringBetween($haystack, $start, $end)
 {
-    $char = strpos($haystack, $start);
-    if ($char === false) {
-        return '';
-    }
-
-    $char += strlen($start);
-    $len = strpos($haystack, $end, $char) - $char;
-
-    return substr($haystack, $char, $len);
+    return trim(strstr(strstr($haystack, $start), $end, true), $start . $end);
 }
 
 function compose(...$functions)

--- a/tests/StringTest.php
+++ b/tests/StringTest.php
@@ -57,6 +57,11 @@ class StringTest extends TestCase
             '',
             firstStringBetween('', '[', ']')
         );
+
+        $this->assertSame(
+            '',
+            firstStringBetween('This is a [custom] string', '[', '#')
+        );
     }
 
     public function testCountVowels()


### PR DESCRIPTION
**decapitalize** 
This function is much faster than the previous one and less complicated.

**firstStringBetween**
This function is a little bit faster, too. But the most important part is, it doesn't fail anymore. With the current one, it'll give you a wrong result if there is a nonexistent start or end. For example:

```php
firstStringBetween('This is a [custom] string', '[', '#')
> string 'cus' (length=3) // instead of an empty string
```

